### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
-## [Unreleased]
+## [v0.1.1] - 2021-08-02
 
 ### Added
 
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Nothing.
+- Aligned platform and instruments fields with best practices.
 
 ## [v0.1.0] - 2021-07-29
 

--- a/src/stactools/alos_dem/__init__.py
+++ b/src/stactools/alos_dem/__init__.py
@@ -8,4 +8,4 @@ def register_plugin(registry):
     registry.register_subcommand(commands.create_alos_dem_command)
 
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/src/stactools/alos_dem/constants.py
+++ b/src/stactools/alos_dem/constants.py
@@ -2,10 +2,8 @@ import datetime
 
 from pystac import Provider, Link
 
-ALOS_DEM_PLATFORM = "Advanced Land Observing Satellite (ALOS)"
-ALOS_DEM_INSTRUMENTS = [
-    "Panchromatic Remote-sensing Instrument for Stereo Mapping (PRISM)"
-]
+ALOS_DEM_PLATFORM = "alos"
+ALOS_DEM_INSTRUMENTS = ["prism"]
 ALOS_DEM_GSD = 30  # meters
 ALOS_DEM_EPSG = 4326
 ALOS_DEM_PROVIDERS = [

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -23,11 +23,8 @@ class StacTest(TestCase):
             datetime.datetime(2016, 12, 7, tzinfo=datetime.timezone.utc))
 
         common_metadata = item.common_metadata
-        self.assertEqual(common_metadata.platform,
-                         "Advanced Land Observing Satellite (ALOS)")
-        self.assertEqual(common_metadata.instruments, [
-            "Panchromatic Remote-sensing Instrument for Stereo Mapping (PRISM)"
-        ])
+        self.assertEqual(common_metadata.platform, "alos")
+        self.assertEqual(common_metadata.instruments, ["prism"])
         self.assertEqual(common_metadata.gsd, 30)
         self.assertEqual(common_metadata.providers, [
             Provider("Japan Aerospace Exploration Agency",


### PR DESCRIPTION
- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
